### PR TITLE
Do not autoload lsp-define-stdio-client

### DIFF
--- a/lsp-haskell.el
+++ b/lsp-haskell.el
@@ -249,7 +249,6 @@ Each option is a plist of (:key :default :title) wherein:
              (set (make-local-variable v) (buffer-local-value v buffer)))))
 ;; ---------------------------------------------------------------------
 
-;;;###autoload
 (lsp-define-stdio-client 'haskell-mode "haskell" 'stdio #'lsp-haskell--get-root
 			  "Haskell Language Server"
 			 '("hie" "--lsp" "-d" "-l" "/tmp/hie.log"))


### PR DESCRIPTION
When both lsp-mode and lsp-haskell are autoloaded, there is usually no guarantee about the autoload order, and it may run into void-function error.

Other lsp-mode clients do not autoload lsp-define-stdio-client. https://github.com/emacs-lsp/lsp-rust/blob/master/lsp-rust.el#L40