### PR TITLE
Use hie-wrapper instead of hie

### DIFF
--- a/lsp-haskell.el
+++ b/lsp-haskell.el
@@ -18,8 +18,10 @@
 
 ;;;###autoload
 (defcustom lsp-haskell-process-path-hie
-  "hie"
-  "The path for starting the haskell-ide-engine server."
+  ;; "hie"
+  "hie-wrapper"
+  "The path for starting the haskell-ide-engine
+server. hie-wrapper exists on HIE master from 2018-06-10"
   :group 'lsp-haskell
   :type '(choice string))
 


### PR DESCRIPTION
This is able to choose the appropriate hie executable based on the GHC
used in the project.

Addresses #16 