### PR TITLE
Add wrapper function for lsp--haskell-hie-command

### DIFF
--- a/lsp-haskell.el
+++ b/lsp-haskell.el
@@ -36,6 +36,26 @@ For a debug log, use `-d -l /tmp/hie.log'."
   :group 'lsp-haskell
   :type '(repeat (string :tag "Argument")))
 
+;;;###autoload
+(defcustom lsp-haskell-process-wrapper-function
+  #'identity
+  "Use this to wrap the haskell-ide-engine process started by lsp-haskell.
+
+For example, use the following the start the hie process in a nix-shell:
+
+(lambda (argv)
+  (append
+   (append (list \"nix-shell\" \"-I\" \".\" \"--command\" )
+           (list (mapconcat 'identity argv \" \"))
+           )
+   (list (concat (lsp-haskell--get-root) \"/shell.nix\"))
+   )
+  )"
+  :group 'lsp-haskell
+  :type '(choice
+          (function-item :tag "None" :value identity)
+          (function :tag "Custom function")))
+
 ;; ---------------------------------------------------------------------
 
 (defvar lsp-haskell--config-options (make-hash-table))
@@ -290,7 +310,7 @@ Each option is a plist of (:key :default :title) wherein:
 (lsp-define-stdio-client lsp-haskell "haskell" #'lsp-haskell--get-root
 			 ;; '("hie" "--lsp" "-d" "-l" "/tmp/hie.log"))
        ;; '("hie" "--lsp" "-d" "-l" "/tmp/hie.log" "--vomit"))
-       (lsp--haskell-hie-command))
+       (funcall lsp-haskell-process-wrapper-function (lsp--haskell-hie-command)))
 
 (defun lsp--haskell-hie-command ()
   "Comamnd and arguments for launching the inferior hie process.


### PR DESCRIPTION
- Add a wrapper function, "lsp-haskell-process-wrapper-function", that is used to
  wrap the "lsp--haskell-hie-command" started by lsp-haskell. It is done in a
  similar style to flycheck-mode and
  haskell-mode (https://github.com/haskell/haskell-mode/blob/dd0ea640fa449d021399a17db65e4d50d3f0f2a9/haskell-customize.el#l74),
  with "identity" being the default value.
- Use the wrapper function in "lsp-define-stdio-client", when
  "lsp--haskell-hie-command" is called.