### PR TITLE
add licence header to make licensing unambiguous

### DIFF
--- a/lsp-haskell.el
+++ b/lsp-haskell.el
@@ -5,6 +5,23 @@
 ;; Keywords: haskell
 ;; URL: https://github.com/emacs-lsp/lsp-haskell
 
+;;; License
+;;
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program; see the file COPYING.  If not, write to
+;; the Free Software Foundation, Inc., 51 Franklin Street, Fifth
+;; Floor, Boston, MA 02110-1301, USA.
+
 ;;; Code:
 
 (require 'haskell)


### PR DESCRIPTION
Although the repository contains a LICENSE file it is not clear whether the code should be licensed under GPL-3.0 or GPL-3.0+. This header makes it clear.