### PR TITLE
Drop support for legacy mode configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,34 +14,15 @@ The library is designed to integrate with existing Emacs IDE frameworks
 
 *This package is still under development, and is not recommended for daily use.*
 
-## Emacs Configuration (new style lsp-mode)
+## Emacs Configuration
 
 Install [`lsp-mode`](https://github.com/emacs-lsp/lsp-mode) first, and either clone
 this repository, or install from MELPA. Add the following to your `.emacs`:
 
 ```emacs-lisp
 (require 'lsp)
-(require 'lsp-ui)
 (require 'lsp-haskell)
-(add-hook 'haskell-mode-hook 'lsp)
-```
-
-## Emacs Configuration (legacy lsp-mode)
-
-Clone this repository, https://github.com/emacs-lsp/lsp-mode and https://github.com/emacs-lsp/lsp-ui
-to suitable paths, and add the following to your `.emacs` or `init.el`
-config file.
-
-```emacs-lisp
-(add-to-list 'load-path "<path to lsp-haskell>")
-(add-to-list 'load-path "<path to lsp-mode>")
-(add-to-list 'load-path "<path to lsp-ui>")
-
-(require 'lsp-ui)
-(require 'lsp-haskell)
-(add-hook 'lsp-mode-hook 'lsp-ui-mode)
-(add-hook 'haskell-mode-hook #'lsp-haskell-enable)
-(add-hook 'haskell-mode-hook 'flycheck-mode)
+(add-hook 'haskell-mode-hook #'lsp)
 ```
 
 Note: All three packages are also available via MELPA.

--- a/lsp-haskell.el
+++ b/lsp-haskell.el
@@ -169,11 +169,6 @@ if projectile way fails"
 
 ;; ---------------------------------------------------------------------
 
-(lsp-define-stdio-client lsp-haskell "haskell" #'lsp-haskell--get-root
-			 ;; '("hie" "--lsp" "-d" "-l" "/tmp/hie.log"))
-       ;; '("hie" "--lsp" "-d" "-l" "/tmp/hie.log" "--vomit"))
-       (funcall lsp-haskell-process-wrapper-function (lsp--haskell-hie-command)))
-
 (defun lsp--haskell-hie-command ()
   "Comamnd and arguments for launching the inferior hie process.
 These are assembled from the customizable variables


### PR DESCRIPTION
This is no longer supported in `lsp`.

Closes #34