### PR TITLE
Fix type-check problem

### DIFF
--- a/lsp-haskell.el
+++ b/lsp-haskell.el
@@ -184,7 +184,7 @@ These are assembled from the customizable variables
 
 (eval-after-load 'lsp '(lsp-register-client
     (make-lsp--client
-     :new-connection (lsp-stdio-connection 'lsp-haskell--hie-command)
+     :new-connection (lsp-stdio-connection (lambda () (lsp-haskell--hie-command)))
      :major-modes '(haskell-mode)
      :server-id 'hie
      ;; :multi-root t


### PR DESCRIPTION
It is caused by this commit.

https://github.com/emacs-lsp/lsp-mode/commit/bdbe9f4f8eeafff929ce768f63fd4f1e57e91cbc#diff-b1e9bc82c3b6bd6e95470e18ee41a19b

since `cl-check-type` cannot determine the type of `lsp-haskell--hie-command`, we can use `lambda` to wrap it.