### PR TITLE
Add support for HLS versions >=0.2.2

### DIFF
--- a/lsp-haskell.el
+++ b/lsp-haskell.el
@@ -317,19 +317,19 @@ These are assembled from the customizable variables
 (defun lsp-haskell-set-formatter-brittany ()
   "Use brittany."
   (interactive)
-  (lsp-haskell-set-formatter :brittany)
+  (lsp-haskell-set-formatter "brittany")
   (lsp-haskell--set-configuration))
 
 (defun lsp-haskell-set-formatter-floskell ()
   "Use floskell."
   (interactive)
-  (lsp-haskell-set-formatter :floskell)
+  (lsp-haskell-set-formatter "floskell")
   (lsp-haskell--set-configuration))
 
 (defun lsp-haskell-set-formatter-ormolu ()
   "Use ormolu."
   (interactive)
-  (lsp-haskell-set-formatter :ormolu)
+  (lsp-haskell-set-formatter "ormolu")
   (lsp-haskell--set-configuration))
 
 ;; ---------------------------------------------------------------------

--- a/lsp-haskell.el
+++ b/lsp-haskell.el
@@ -194,9 +194,9 @@ These are assembled from the customizable variables
    (if (string-match
         "haskell-language-server-wrapper" lsp-haskell-process-path-hie)
        (let* ((hls-version-string
-              (shell-command-to-string
-               (combine-and-quote-strings
-                (list lsp-haskell-process-path-hie "--version"))))
+               (shell-command-to-string
+                (combine-and-quote-strings
+                 (list lsp-haskell-process-path-hie "--version"))))
               (hls-version
                (progn
                  (string-match


### PR DESCRIPTION
Addresses issue #73 to support HLS >=0.2.2 while trying to retain existing behavior for everything else.

Also, I'm new to elisp and open source. Please let me know if I've done something wrong.