### PR TITLE
Use strings instead of symbols to identify formatters.

### DIFF
--- a/lsp-haskell.el
+++ b/lsp-haskell.el
@@ -299,19 +299,19 @@ These are assembled from the customizable variables
 (defun lsp-haskell-set-formatter-brittany ()
   "Use brittany."
   (interactive)
-  (lsp-haskell-set-formatter :brittany)
+  (lsp-haskell-set-formatter "brittany")
   (lsp-haskell--set-configuration))
 
 (defun lsp-haskell-set-formatter-floskell ()
   "Use floskell."
   (interactive)
-  (lsp-haskell-set-formatter :floskell)
+  (lsp-haskell-set-formatter "floskell")
   (lsp-haskell--set-configuration))
 
 (defun lsp-haskell-set-formatter-ormolu ()
   "Use ormolu."
   (interactive)
-  (lsp-haskell-set-formatter :ormolu)
+  (lsp-haskell-set-formatter "ormolu")
   (lsp-haskell--set-configuration))
 
 ;; ---------------------------------------------------------------------


### PR DESCRIPTION
See #75. This seems to work for me in Emacs 27.1, as well as Emacs 26.3. Thank you!