### PR TITLE
Use the haskell-language-server-wrapper to launch hls

### DIFF
--- a/lsp-haskell.el
+++ b/lsp-haskell.el
@@ -88,7 +88,7 @@
 ;; Non-language server options
 
 (defcustom lsp-haskell-server-path
-  "haskell-language-server"
+  "haskell-language-server-wrapper"
   "The language server executable. Can be something on the $PATH (e.g. 'ghcide') or a path to an executable itself."
   :group 'lsp-haskell
   :type 'string)


### PR DESCRIPTION
This has logic in it to match the project GHC version.

This was the default prior to the recent reorganization