### PR TITLE
make Nix env wrapper suggestion a total solution

### DIFF
--- a/lsp-haskell.el
+++ b/lsp-haskell.el
@@ -110,13 +110,13 @@ For a debug log when using haskell-language-server, use `-d -l /tmp/hls.log'."
 (defcustom lsp-haskell-server-wrapper-function
   #'identity
   "Use this to wrap the language server process started by lsp-haskell.
-For example, use the following the start the process in a nix-shell:
+For example, use the following the start the process in a nix-shell (requires nix-sandbox package):
 (lambda (argv)
   (append
    (append (list \"nix-shell\" \"-I\" \".\" \"--command\" )
            (list (mapconcat 'identity argv \" \"))
            )
-   (list (concat (lsp-haskell--get-root) \"/shell.nix\"))
+   (list (nix-current-sandbox))
    )
   )"
   :group 'lsp-haskell


### PR DESCRIPTION
The prior code is a partial solution, `shell.nix` is not required to exist, `default.nix` can be used instead, and even with looking only in Haskell project root dir - the relevant `{default,shell}.nix` can be found arbitrary number of the levels up the filesystem hierarchy (practical limit is Git the repo).

The default standardized `nix-shell` behavior and expectation is that if `shell.nix` not found - `nix-shell` loads `default.nix` (which, if exists - is always possible, since `default.nix` describes package derivation, and package derivation always can be loaded as shell environment by Nix), so there are a number of projects that do not have `shell.nix`, but, expect `default.nix` to be used instead.

And then there is are projects where `shell.nix` or `default.nix` can be in ../ or up the tree - there is a subset of the project with those types of quirks, for example, Target company Nix configurations promote that approach. This all (for all intents and purposes - all) cases is solved by using a well-supported/used library function from the https://github.com/travisbhartwell/nix-emacs, package `nix-sandbox`, function `nix-current-sandbox` - "searches for a sandbox file starting from the current working directory".