### PR TITLE
add completion-in-comment settings while registering as lsp-client

### DIFF
--- a/lsp-haskell.el
+++ b/lsp-haskell.el
@@ -263,6 +263,8 @@ and `lsp-haskell-server-args' and `lsp-haskell-server-wrapper-function'."
     ;; This is somewhat irrelevant, but it is listed in lsp-language-id-configuration, so
     ;; we should set something consistent here.
     :language-id "haskell"
+    ;; This is required for completions to works inside language pragma statements
+    :completion-in-comments? t
     ))
 
 ;; ---------------------------------------------------------------------


### PR DESCRIPTION
Fixes https://github.com/emacs-lsp/lsp-haskell/issues/95