### PR TITLE
changed: lsp-haskell-completion-snippets-on default: t -> lsp-enable-…

### DIFF
--- a/lsp-haskell.el
+++ b/lsp-haskell.el
@@ -68,7 +68,7 @@ Turn off to only generate diagnostics on file save."
   :group 'lsp-haskell
   :type 'boolean)
 (defcustom lsp-haskell-completion-snippets-on
-  t
+  lsp-enable-snippet
   "Show snippets with type information when using code completion."
   :group 'lsp-haskell
   :type 'boolean)


### PR DESCRIPTION
…snippet

If lsp-enable-snippet is disabled, snippet generation will be useless, so it is preferable to turn it off.

I also had a long time trouble with setting this option to nil on lsp-haskell without disabling the snippet.
It's good to provide a variable ledge for such users.