### PR TITLE
Remove lsp-haskell--get-root from docstring

### DIFF
--- a/lsp-haskell.el
+++ b/lsp-haskell.el
@@ -248,7 +248,7 @@ For example, use the following the start the process in a nix-shell:
    (append (list \"nix-shell\" \"-I\" \".\" \"--command\" )
            (list (mapconcat 'identity argv \" \"))
            )
-   (list (concat (lsp-haskell--get-root) \"/shell.nix\"))
+   (list (concat (lsp--suggest-project-root) \"/shell.nix\"))
    )
   )"
   :group 'lsp-haskell


### PR DESCRIPTION
`'lsp-haskell--get-root` was an alias for `'lsp--suggest-project-root`,
and was removed in commit 9c0203b7cef395d3d5e0fcfacf0873419896d1a9.

However, it remained in this doc-string example value for
`lsp-haskell-server-wrapper-function`. Using it led to a confusing
bug (at least for me) where `'lsp--server-binary-present?` would return
`nil`, leading to the "lsp-haskell is not configured" message.

Using `'lsp--suggest-project-root` instead works as before.