### PR TITLE
fix: Drop support for Emacs 26.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         emacs-version:
-          - 26.3
           - 27.2
           - 28.2
           - 29.1

--- a/Eask
+++ b/Eask
@@ -12,7 +12,7 @@
 (source "gnu")
 (source "melpa")
 
-(depends-on "emacs" "24.3")
+(depends-on "emacs" "27.1")
 (depends-on "lsp-mode")
 (depends-on "haskell-mode")
 

--- a/lsp-haskell.el
+++ b/lsp-haskell.el
@@ -1,7 +1,7 @@
 ;;; lsp-haskell.el --- Haskell support for lsp-mode
 
 ;; Version: 1.1
-;; Package-Requires: ((emacs "24.3") (lsp-mode "3.0") (haskell-mode "16.1"))
+;; Package-Requires: ((emacs "27.1") (lsp-mode "3.0") (haskell-mode "16.1"))
 ;; Keywords: haskell
 ;; URL: https://github.com/emacs-lsp/lsp-haskell
 


### PR DESCRIPTION
See https://github.com/emacs-lsp/lsp-mode/pull/4126.