### PR TITLE
Updating configuration to support HLS 2.9.0.1 schema

### DIFF
--- a/lsp-haskell.el
+++ b/lsp-haskell.el
@@ -441,7 +441,7 @@ but will take exponentially more time."
   :lsp-path "haskell.plugin.rename.globalOn")
 
 (lsp-defcustom lsp-haskell-plugin-semantic-tokens-global-on t
-  "Enables semanticTokens plugin"
+  "Enables semantic tokens plugin"
   :type 'boolean
   :group 'lsp-haskell-plugins
   :package-version '(lsp-mode . "8.0.1")

--- a/lsp-haskell.el
+++ b/lsp-haskell.el
@@ -235,7 +235,7 @@ but will take exponentially more time."
   :type 'boolean
   :lsp-path "haskell.plugin.refineImports.globalOn")
 
-;; Updated for haskell-language-server 2.1.0.0
+;; Updated for haskell-language-server 2.9.0.1
 
 (lsp-defcustom lsp-haskell-plugin-cabal-code-actions-on t
   "Enables cabal code actions"
@@ -250,6 +250,13 @@ but will take exponentially more time."
   :group 'lsp-haskell-plugins
   :package-version '(lsp-mode . "8.0.1")
   :lsp-path "haskell.plugin.cabal.completionOn")
+
+(lsp-defcustom lsp-haskell-plugin-cabal-diagnostics-on t
+  "Enables cabal diagnostics"
+  :type 'boolean
+  :group 'lsp-haskell-plugins
+  :package-version '(lsp-mode . "8.0.1")
+  :lsp-path "haskell.plugin.cabal.diagnosticsOn")
 
 (lsp-defcustom lsp-haskell-plugin-pragmas-suggest-global-on t
   "Enables pragmas-suggest plugin"
@@ -434,11 +441,102 @@ but will take exponentially more time."
   :lsp-path "haskell.plugin.rename.globalOn")
 
 (lsp-defcustom lsp-haskell-plugin-semantic-tokens-global-on t
-  "Enables semantic-tokens plugin"
+  "Enables semanticTokens plugin"
   :type 'boolean
   :group 'lsp-haskell-plugins
   :package-version '(lsp-mode . "8.0.1")
   :lsp-path "haskell.plugin.semanticTokens.globalOn")
+
+(lsp-defcustom lsp-haskell-plugin-semantic-tokens-config-class-method-token "method"
+  "Semantic tokens class method token"
+  :type 'string
+  :group 'lsp-haskell-plugins
+  :package-version '(lsp-mode . "8.0.1")
+  :lsp-path "haskell.plugin.semanticTokens.config.classMethodToken")
+
+(lsp-defcustom lsp-haskell-plugin-semantic-tokens-config-class-token "class"
+  "Semantic tokens class token"
+  :type 'string
+  :group 'lsp-haskell-plugins
+  :package-version '(lsp-mode . "8.0.1")
+  :lsp-path "haskell.plugin.semanticTokens.config.classToken")
+
+(lsp-defcustom lsp-haskell-plugin-semantic-tokens-config-data-constructor-token "enumMember"
+  "Semantic tokens data constructor token"
+  :type 'string
+  :group 'lsp-haskell-plugins
+  :package-version '(lsp-mode . "8.0.1")
+  :lsp-path "haskell.plugin.semanticTokens.config.dataConstructorToken")
+
+(lsp-defcustom lsp-haskell-plugin-semantic-tokens-config-function-token "function"
+  "Semantic tokens function token"
+  :type 'string
+  :group 'lsp-haskell-plugins
+  :package-version '(lsp-mode . "8.0.1")
+  :lsp-path "haskell.plugin.semanticTokens.config.functionToken")
+
+(lsp-defcustom lsp-haskell-plugin-semantic-tokens-config-module-token "module"
+  "Semantic tokens module token"
+  :type 'string
+  :group 'lsp-haskell-plugins
+  :package-version '(lsp-mode . "8.0.1")
+  :lsp-path "haskell.plugin.semanticTokens.config.moduleToken")
+
+(lsp-defcustom lsp-haskell-plugin-semantic-tokens-config-operator-token "operator"
+  "Semantic tokens operator token"
+  :type 'string
+  :group 'lsp-haskell-plugins
+  :package-version '(lsp-mode . "8.0.1")
+  :lsp-path "haskell.plugin.semanticTokens.config.operatorToken")
+
+(lsp-defcustom lsp-haskell-plugin-semantic-tokens-config-pattern-synonym-token "macro"
+  "Semantic tokens pattern synonym token"
+  :type 'string
+  :group 'lsp-haskell-plugins
+  :package-version '(lsp-mode . "8.0.1")
+  :lsp-path "haskell.plugin.semanticTokens.config.patternSynonymToken")
+
+(lsp-defcustom lsp-haskell-plugin-semantic-tokens-config-record-field-token "property"
+  "Semantic tokens record field token"
+  :type 'string
+  :group 'lsp-haskell-plugins
+  :package-version '(lsp-mode . "8.0.1")
+  :lsp-path "haskell.plugin.semanticTokens.config.recordFieldToken")
+
+(lsp-defcustom lsp-haskell-plugin-semantic-tokens-config-type-constructor-token "enum"
+  "Semantic tokens type constructor token"
+  :type 'string
+  :group 'lsp-haskell-plugins
+  :package-version '(lsp-mode . "8.0.1")
+  :lsp-path "haskell.plugin.semanticTokens.config.typeConstructorToken")
+
+(lsp-defcustom lsp-haskell-plugin-semantic-tokens-config-type-family-token "interface"
+  "Semantic tokens type family token"
+  :type 'string
+  :group 'lsp-haskell-plugins
+  :package-version '(lsp-mode . "8.0.1")
+  :lsp-path "haskell.plugin.semanticTokens.config.typeFamilyToken")
+
+(lsp-defcustom lsp-haskell-plugin-semantic-tokens-config-type-synonym-token "type"
+  "Semantic tokens type synonym token"
+  :type 'string
+  :group 'lsp-haskell-plugins
+  :package-version '(lsp-mode . "8.0.1")
+  :lsp-path "haskell.plugin.semanticTokens.config.typeSynonymToken")
+
+(lsp-defcustom lsp-haskell-plugin-semantic-tokens-config-type-variable-token "typeParameter"
+  "Semantic tokens type variable token"
+  :type 'string
+  :group 'lsp-haskell-plugins
+  :package-version '(lsp-mode . "8.0.1")
+  :lsp-path "haskell.plugin.semanticTokens.config.typeVariableToken")
+
+(lsp-defcustom lsp-haskell-plugin-semantic-tokens-config-variable-token "variable"
+  "Semantic tokens variable token"
+  :type 'string
+  :group 'lsp-haskell-plugins
+  :package-version '(lsp-mode . "8.0.1")
+  :lsp-path "haskell.plugin.semanticTokens.config.variableToken")
 
 ;; ---------------------------------------------------------------------
 ;; Non-language server options

--- a/lsp-haskell.el
+++ b/lsp-haskell.el
@@ -235,7 +235,7 @@ but will take exponentially more time."
   :type 'boolean
   :lsp-path "haskell.plugin.refineImports.globalOn")
 
-;; Updated for haskell-language-server 2.9.0.1
+;; Updated for haskell-language-server 2.1.0.0
 
 (lsp-defcustom lsp-haskell-plugin-cabal-code-actions-on t
   "Enables cabal code actions"
@@ -250,13 +250,6 @@ but will take exponentially more time."
   :group 'lsp-haskell-plugins
   :package-version '(lsp-mode . "8.0.1")
   :lsp-path "haskell.plugin.cabal.completionOn")
-
-(lsp-defcustom lsp-haskell-plugin-cabal-diagnostics-on t
-  "Enables cabal diagnostics"
-  :type 'boolean
-  :group 'lsp-haskell-plugins
-  :package-version '(lsp-mode . "8.0.1")
-  :lsp-path "haskell.plugin.cabal.diagnosticsOn")
 
 (lsp-defcustom lsp-haskell-plugin-pragmas-suggest-global-on t
   "Enables pragmas-suggest plugin"
@@ -440,103 +433,211 @@ but will take exponentially more time."
   :package-version '(lsp-mode . "8.0.1")
   :lsp-path "haskell.plugin.rename.globalOn")
 
-(lsp-defcustom lsp-haskell-plugin-semantic-tokens-global-on t
-  "Enables semantic tokens plugin"
+;; Updated for haskell-language-server 2.9.0.1
+
+(lsp-defcustom lsp-haskell-plugin-cabal-fmt-config-path "cabal-fmt"
+  "Set path to 'cabal-fmt' executable"
+  :type 'string
+  :group 'lsp-haskell-plugins
+  :package-version '(lsp-mode . "9.0.0")
+  :lsp-path "haskell.plugin.cabal-fmt.config.path")
+
+(lsp-defcustom lsp-haskell-plugin-cabal-gild-config-path "cabal-gild"
+  "Set path to 'cabal-gild' executable"
+  :type 'string
+  :group 'lsp-haskell-plugins
+  :package-version '(lsp-mode . "9.0.0")
+  :lsp-path "haskell.plugin.cabal-gild.config.path")
+
+(lsp-defcustom lsp-haskell-plugin-cabal-diagnostics-on t
+  "Enables cabal diagnostics"
   :type 'boolean
   :group 'lsp-haskell-plugins
-  :package-version '(lsp-mode . "8.0.1")
-  :lsp-path "haskell.plugin.semanticTokens.globalOn")
+  :package-version '(lsp-mode . "9.0.0")
+  :lsp-path "haskell.plugin.cabal.diagnosticsOn")
 
-(lsp-defcustom lsp-haskell-plugin-semantic-tokens-config-class-method-token "method"
-  "Semantic tokens class method token"
+(lsp-defcustom lsp-haskell-plugin-fourmolu-config-path "fourmolu"
+  "Set path to executable (for \"external\" mode)."
   :type 'string
   :group 'lsp-haskell-plugins
-  :package-version '(lsp-mode . "8.0.1")
+  :package-version '(lsp-mode . "9.0.0")
+  :lsp-path "haskell.plugin.fourmolu.config.path")
+
+(lsp-defcustom lsp-haskell-plugin-semantic-tokens-config-class-method-token
+  "method"
+  "LSP semantic token type to use for typeclass methods"
+  :type '(choice (const "namespace") (const "type") (const "class") (const "enum")
+          (const "interface") (const "struct") (const "typeParameter")
+          (const "parameter") (const "variable") (const "property") (const "enumMember")
+          (const "event") (const "function") (const "method") (const "macro")
+          (const "keyword") (const "modifier") (const "comment") (const "string")
+          (const "number") (const "regexp") (const "operator") (const "decorator"))
+  :group 'lsp-haskell-plugins
+  :package-version '(lsp-mode . "9.0.0")
   :lsp-path "haskell.plugin.semanticTokens.config.classMethodToken")
 
-(lsp-defcustom lsp-haskell-plugin-semantic-tokens-config-class-token "class"
-  "Semantic tokens class token"
-  :type 'string
+(lsp-defcustom lsp-haskell-plugin-semantic-tokens-config-class-token
+  "class"
+  "LSP semantic token type to use for typeclasses"
+  :type '(choice (const "namespace") (const "type") (const "class") (const "enum")
+          (const "interface") (const "struct") (const "typeParameter")
+          (const "parameter") (const "variable") (const "property") (const "enumMember")
+          (const "event") (const "function") (const "method") (const "macro")
+          (const "keyword") (const "modifier") (const "comment") (const "string")
+          (const "number") (const "regexp") (const "operator") (const "decorator"))
   :group 'lsp-haskell-plugins
-  :package-version '(lsp-mode . "8.0.1")
+  :package-version '(lsp-mode . "9.0.0")
   :lsp-path "haskell.plugin.semanticTokens.config.classToken")
 
-(lsp-defcustom lsp-haskell-plugin-semantic-tokens-config-data-constructor-token "enumMember"
-  "Semantic tokens data constructor token"
-  :type 'string
+(lsp-defcustom lsp-haskell-plugin-semantic-tokens-config-data-constructor-token
+  "enumMember"
+  "LSP semantic token type to use for data constructors"
+  :type '(choice (const "namespace") (const "type") (const "class") (const "enum")
+          (const "interface") (const "struct") (const "typeParameter")
+          (const "parameter") (const "variable") (const "property") (const "enumMember")
+          (const "event") (const "function") (const "method") (const "macro")
+          (const "keyword") (const "modifier") (const "comment") (const "string")
+          (const "number") (const "regexp") (const "operator") (const "decorator"))
   :group 'lsp-haskell-plugins
-  :package-version '(lsp-mode . "8.0.1")
+  :package-version '(lsp-mode . "9.0.0")
   :lsp-path "haskell.plugin.semanticTokens.config.dataConstructorToken")
 
-(lsp-defcustom lsp-haskell-plugin-semantic-tokens-config-function-token "function"
-  "Semantic tokens function token"
-  :type 'string
+(lsp-defcustom lsp-haskell-plugin-semantic-tokens-config-function-token
+  "function"
+  "LSP semantic token type to use for functions"
+  :type '(choice (const "namespace") (const "type") (const "class") (const "enum")
+          (const "interface") (const "struct") (const "typeParameter")
+          (const "parameter") (const "variable") (const "property") (const "enumMember")
+          (const "event") (const "function") (const "method") (const "macro")
+          (const "keyword") (const "modifier") (const "comment") (const "string")
+          (const "number") (const "regexp") (const "operator") (const "decorator"))
   :group 'lsp-haskell-plugins
-  :package-version '(lsp-mode . "8.0.1")
+  :package-version '(lsp-mode . "9.0.0")
   :lsp-path "haskell.plugin.semanticTokens.config.functionToken")
 
-(lsp-defcustom lsp-haskell-plugin-semantic-tokens-config-module-token "module"
-  "Semantic tokens module token"
-  :type 'string
+(lsp-defcustom lsp-haskell-plugin-semantic-tokens-config-module-token
+  "namespace"
+  "LSP semantic token type to use for modules"
+  :type '(choice (const "namespace") (const "type") (const "class") (const "enum")
+          (const "interface") (const "struct") (const "typeParameter")
+          (const "parameter") (const "variable") (const "property") (const "enumMember")
+          (const "event") (const "function") (const "method") (const "macro")
+          (const "keyword") (const "modifier") (const "comment") (const "string")
+          (const "number") (const "regexp") (const "operator") (const "decorator"))
   :group 'lsp-haskell-plugins
-  :package-version '(lsp-mode . "8.0.1")
+  :package-version '(lsp-mode . "9.0.0")
   :lsp-path "haskell.plugin.semanticTokens.config.moduleToken")
 
-(lsp-defcustom lsp-haskell-plugin-semantic-tokens-config-operator-token "operator"
-  "Semantic tokens operator token"
-  :type 'string
+(lsp-defcustom lsp-haskell-plugin-semantic-tokens-config-operator-token
+  "operator"
+  "LSP semantic token type to use for operators"
+  :type '(choice (const "namespace") (const "type") (const "class") (const "enum")
+          (const "interface") (const "struct") (const "typeParameter")
+          (const "parameter") (const "variable") (const "property") (const "enumMember")
+          (const "event") (const "function") (const "method") (const "macro")
+          (const "keyword") (const "modifier") (const "comment") (const "string")
+          (const "number") (const "regexp") (const "operator") (const "decorator"))
   :group 'lsp-haskell-plugins
-  :package-version '(lsp-mode . "8.0.1")
+  :package-version '(lsp-mode . "9.0.0")
   :lsp-path "haskell.plugin.semanticTokens.config.operatorToken")
 
-(lsp-defcustom lsp-haskell-plugin-semantic-tokens-config-pattern-synonym-token "macro"
-  "Semantic tokens pattern synonym token"
-  :type 'string
+(lsp-defcustom lsp-haskell-plugin-semantic-tokens-config-pattern-synonym-token
+  "macro"
+  "LSP semantic token type to use for pattern synonyms"
+  :type '(choice (const "namespace") (const "type") (const "class") (const "enum")
+          (const "interface") (const "struct") (const "typeParameter")
+          (const "parameter") (const "variable") (const "property") (const "enumMember")
+          (const "event") (const "function") (const "method") (const "macro")
+          (const "keyword") (const "modifier") (const "comment") (const "string")
+          (const "number") (const "regexp") (const "operator") (const "decorator"))
   :group 'lsp-haskell-plugins
-  :package-version '(lsp-mode . "8.0.1")
+  :package-version '(lsp-mode . "9.0.0")
   :lsp-path "haskell.plugin.semanticTokens.config.patternSynonymToken")
 
-(lsp-defcustom lsp-haskell-plugin-semantic-tokens-config-record-field-token "property"
-  "Semantic tokens record field token"
-  :type 'string
+(lsp-defcustom lsp-haskell-plugin-semantic-tokens-config-record-field-token
+  "property"
+  "LSP semantic token type to use for record fields"
+  :type '(choice (const "namespace") (const "type") (const "class") (const "enum")
+          (const "interface") (const "struct") (const "typeParameter")
+          (const "parameter") (const "variable") (const "property") (const "enumMember")
+          (const "event") (const "function") (const "method") (const "macro")
+          (const "keyword") (const "modifier") (const "comment") (const "string")
+          (const "number") (const "regexp") (const "operator") (const "decorator"))
   :group 'lsp-haskell-plugins
-  :package-version '(lsp-mode . "8.0.1")
+  :package-version '(lsp-mode . "9.0.0")
   :lsp-path "haskell.plugin.semanticTokens.config.recordFieldToken")
 
-(lsp-defcustom lsp-haskell-plugin-semantic-tokens-config-type-constructor-token "enum"
-  "Semantic tokens type constructor token"
-  :type 'string
+(lsp-defcustom lsp-haskell-plugin-semantic-tokens-config-type-constructor-token
+  "enum"
+  "LSP semantic token type to use for type constructors"
+  :type '(choice (const "namespace") (const "type") (const "class") (const "enum")
+          (const "interface") (const "struct") (const "typeParameter")
+          (const "parameter") (const "variable") (const "property") (const "enumMember")
+          (const "event") (const "function") (const "method") (const "macro")
+          (const "keyword") (const "modifier") (const "comment") (const "string")
+          (const "number") (const "regexp") (const "operator") (const "decorator"))
   :group 'lsp-haskell-plugins
-  :package-version '(lsp-mode . "8.0.1")
+  :package-version '(lsp-mode . "9.0.0")
   :lsp-path "haskell.plugin.semanticTokens.config.typeConstructorToken")
 
-(lsp-defcustom lsp-haskell-plugin-semantic-tokens-config-type-family-token "interface"
-  "Semantic tokens type family token"
-  :type 'string
+(lsp-defcustom lsp-haskell-plugin-semantic-tokens-config-type-family-token
+  "interface"
+  "LSP semantic token type to use for type families"
+  :type '(choice (const "namespace") (const "type") (const "class") (const "enum")
+          (const "interface") (const "struct") (const "typeParameter")
+          (const "parameter") (const "variable") (const "property") (const "enumMember")
+          (const "event") (const "function") (const "method") (const "macro")
+          (const "keyword") (const "modifier") (const "comment") (const "string")
+          (const "number") (const "regexp") (const "operator") (const "decorator"))
   :group 'lsp-haskell-plugins
-  :package-version '(lsp-mode . "8.0.1")
+  :package-version '(lsp-mode . "9.0.0")
   :lsp-path "haskell.plugin.semanticTokens.config.typeFamilyToken")
 
-(lsp-defcustom lsp-haskell-plugin-semantic-tokens-config-type-synonym-token "type"
-  "Semantic tokens type synonym token"
-  :type 'string
+(lsp-defcustom lsp-haskell-plugin-semantic-tokens-config-type-synonym-token
+  "type"
+  "LSP semantic token type to use for type synonyms"
+  :type '(choice (const "namespace") (const "type") (const "class") (const "enum")
+          (const "interface") (const "struct") (const "typeParameter")
+          (const "parameter") (const "variable") (const "property") (const "enumMember")
+          (const "event") (const "function") (const "method") (const "macro")
+          (const "keyword") (const "modifier") (const "comment") (const "string")
+          (const "number") (const "regexp") (const "operator") (const "decorator"))
   :group 'lsp-haskell-plugins
-  :package-version '(lsp-mode . "8.0.1")
+  :package-version '(lsp-mode . "9.0.0")
   :lsp-path "haskell.plugin.semanticTokens.config.typeSynonymToken")
 
-(lsp-defcustom lsp-haskell-plugin-semantic-tokens-config-type-variable-token "typeParameter"
-  "Semantic tokens type variable token"
-  :type 'string
+(lsp-defcustom lsp-haskell-plugin-semantic-tokens-config-type-variable-token
+  "typeParameter"
+  "LSP semantic token type to use for type variables"
+  :type '(choice (const "namespace") (const "type") (const "class") (const "enum")
+          (const "interface") (const "struct") (const "typeParameter")
+          (const "parameter") (const "variable") (const "property") (const "enumMember")
+          (const "event") (const "function") (const "method") (const "macro")
+          (const "keyword") (const "modifier") (const "comment") (const "string")
+          (const "number") (const "regexp") (const "operator") (const "decorator"))
   :group 'lsp-haskell-plugins
-  :package-version '(lsp-mode . "8.0.1")
+  :package-version '(lsp-mode . "9.0.0")
   :lsp-path "haskell.plugin.semanticTokens.config.typeVariableToken")
 
-(lsp-defcustom lsp-haskell-plugin-semantic-tokens-config-variable-token "variable"
-  "Semantic tokens variable token"
-  :type 'string
+(lsp-defcustom lsp-haskell-plugin-semantic-tokens-config-variable-token
+  "variable"
+  "LSP semantic token type to use for variables"
+  :type '(choice (const "namespace") (const "type") (const "class") (const "enum")
+          (const "interface") (const "struct") (const "typeParameter")
+          (const "parameter") (const "variable") (const "property") (const "enumMember")
+          (const "event") (const "function") (const "method") (const "macro")
+          (const "keyword") (const "modifier") (const "comment") (const "string")
+          (const "number") (const "regexp") (const "operator") (const "decorator"))
   :group 'lsp-haskell-plugins
-  :package-version '(lsp-mode . "8.0.1")
+  :package-version '(lsp-mode . "9.0.0")
   :lsp-path "haskell.plugin.semanticTokens.config.variableToken")
+
+(lsp-defcustom lsp-haskell-plugin-semantic-tokens-global-on nil
+  "Enables semanticTokens plugin"
+  :type 'boolean
+  :group 'lsp-haskell-plugins
+  :package-version '(lsp-mode . "9.0.0")
+  :lsp-path "haskell.plugin.semanticTokens.globalOn")
 
 ;; ---------------------------------------------------------------------
 ;; Non-language server options

--- a/lsp-haskell.el
+++ b/lsp-haskell.el
@@ -1,4 +1,4 @@
-;;; lsp-haskell.el --- Haskell support for lsp-mode
+;;; lsp-haskell.el --- Haskell support for lsp-mode -*- lexical-binding: t; -*-
 
 ;; Version: 1.1
 ;; Package-Requires: ((emacs "27.1") (lsp-mode "3.0") (haskell-mode "16.1"))


### PR DESCRIPTION
Updating lsp-haskell plugins custom variables group to reflect HLS 2.9.0.1 configuration schema using `haskell-language-server generate-default-config`