### PR TITLE
Add custom `lsp-clients-extract-signature-on-hover`

### DIFF
--- a/lsp-haskell.el
+++ b/lsp-haskell.el
@@ -495,6 +495,26 @@ Note that this must be set to true in order to get completion of pragmas."
 ;; ---------------------------------------------------------------------
 ;; Starting the server and registration with lsp-mode
 
+(cl-defmethod lsp-clients-extract-signature-on-hover (contents (_server-id (eql lsp-haskell)))
+  "Display the type signature of the function under point."
+  (let* ((groups (--filter (s-equals? "```haskell" (car it))
+                           (-partition-by #'s-blank?
+                                          (->> (lsp-get contents :value)
+                                               s-trim
+                                               s-lines))))
+         (type-sig-group
+          (car (--filter (--any? (s-contains? (symbol-name (symbol-at-point))
+                                              it)
+                                 it)
+                         groups))))
+    (lsp--render-string
+     (->> (or type-sig-group (car groups))
+          (-drop 1)                     ; ``` LANG
+          (-drop-last 1)                ; ```
+          (-map #'s-trim)
+          (s-join " "))
+     "haskell")))
+
 (defun lsp-haskell--server-command ()
   "Command and arguments for launching the inferior language server process.
 These are assembled from the customizable variables `lsp-haskell-server-path'


### PR DESCRIPTION
It seems like https://github.com/emacs-lsp/lsp-mode/issues/4362 didn't get any traction, so I'm following what was discussed in https://github.com/emacs-lsp/lsp-haskell/issues/151 and am creating an individual PR here instead.

Before:
![2024-08-17-144642_1108x206_scrot](https://github.com/user-attachments/assets/7670cea0-0e98-4ac9-b252-ead64c35bdae)

After:
![2024-08-17-144117_903x177_scrot](https://github.com/user-attachments/assets/b366e763-24fe-49c7-bf62-3aad913078e5)

---

### Commit Summary

#### [Add custom lsp-clients-extract-signature-on-hover](https://github.com/emacs-lsp/lsp-haskell/commit/45234e8e6c134091acb85f1aae78da8ac1058ca2)

This fixes a case where a type signature would be broken up over multiple lines, and we only display the first of these.

Fixes: https://github.com/emacs-lsp/lsp-haskell/issues/151
Related: https://github.com/emacs-lsp/lsp-mode/issues/4362
Related: https://github.com/emacs-lsp/lsp-mode/pull/1740