### PR TITLE
Do not depend on nor require `haskell-mode`

### DIFF
--- a/Eask
+++ b/Eask
@@ -14,7 +14,6 @@
 
 (depends-on "emacs" "27.1")
 (depends-on "lsp-mode")
-(depends-on "haskell-mode")
 
 (development
  (depends-on "f")

--- a/README.md
+++ b/README.md
@@ -23,9 +23,8 @@ Do not skip this!
 It has important information.
 
 `lsp-mode` automatically requires the `lsp-haskell` package , so you do not need to `require` `lsp-haskell` unless you like being explicit.
-Similarly, `lsp-haskell` automatically requires the `haskell-mode` package, so you do not need to `require` `haskell-mode`.
 
-You will need to set some hooks to ensure that `lsp-mode` is triggered when the `haskell-mode` major mode is entered.
+You will need to set some hooks to ensure that `lsp-mode` is triggered when your Haskell major mode (e.g., `haskell-mode` or `haskell-ts-mode`) is entered.
 
 ```emacs-lisp
 (add-hook 'haskell-mode-hook #'lsp)

--- a/lsp-haskell.el
+++ b/lsp-haskell.el
@@ -1,7 +1,7 @@
 ;;; lsp-haskell.el --- Haskell support for lsp-mode -*- lexical-binding: t; -*-
 
 ;; Version: 1.1
-;; Package-Requires: ((emacs "27.1") (lsp-mode "3.0") (haskell-mode "16.1"))
+;; Package-Requires: ((emacs "27.1") (lsp-mode "3.0"))
 ;; Keywords: haskell
 ;; URL: https://github.com/emacs-lsp/lsp-haskell
 
@@ -29,7 +29,6 @@
 ;;; Code:
 
 (require 'lsp-mode)
-(require 'haskell-mode)
 
 ;; ---------------------------------------------------------------------
 ;; Configuration


### PR DESCRIPTION
Solves #188.

I tried using `lsp-haskell` with `haskell-mode`, and `haskell-ts-mode`, and both seems to work. However, I suggest other people testing their setups.