### PR TITLE
docs: various fixes with mkdocs ci build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,15 +8,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: MkDocs
-        run: |
-          cp -rf README.md images docs
-          docker run --rm -v ${PWD}:/docs squidfunk/mkdocs-material -- build
-
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+        uses: actions/checkout@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./site
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+
+      - run: pip install mkdocs-material mkdocs-awesome-pages-plugin mkdocs-git-revision-date-localized-plugin
+      - run: cp -r README.md images docs
+      - run: mkdocs gh-deploy --force

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
             experimental: true
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: jcs090218/setup-emacs@master
       with:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 lsp-haskell
 ===========
 
-[![MELPA](https://melpa.org/packages/lsp-haskell-badge.svg)](https://melpa.org/#/lsp-haskell) [![Build Status](https://travis-ci.com/emacs-lsp/lsp-haskell.svg?branch=master)](https://travis-ci.com/emacs-lsp/lsp-haskell)
+[![MELPA](https://melpa.org/packages/lsp-haskell-badge.svg)](https://melpa.org/#/lsp-haskell) ![Build Status](https://github.com/emacs-lsp/lsp-haskell/actions/workflows/test.yml/badge.svg)
 
 An Emacs Lisp library for interacting with a Haskell language server such as [`haskell-language-server`](https://github.com/haskell/haskell-language-server/) using Microsoft's [Language Server Protocol](https://github.com/Microsoft/language-server-protocol/).
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 lsp-haskell
 ===========
 
-[![MELPA](https://melpa.org/packages/lsp-haskell-badge.svg)](https://melpa.org/#/lsp-haskell) ![Build Status](https://github.com/emacs-lsp/lsp-haskell/actions/workflows/test.yml/badge.svg)
+[![MELPA](https://melpa.org/packages/lsp-haskell-badge.svg)](https://melpa.org/#/lsp-haskell) ![Build Status](https://github.com/emacs-lsp/lsp-haskell/actions/workflows/test.yml/badge.svg) ![Docs](https://github.com/emacs-lsp/lsp-haskell/actions/workflows/docs.yml/badge.svg)
 
 An Emacs Lisp library for interacting with a Haskell language server such as [`haskell-language-server`](https://github.com/haskell/haskell-language-server/) using Microsoft's [Language Server Protocol](https://github.com/Microsoft/language-server-protocol/).
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,8 +25,8 @@ repo_url: https://github.com/emacs-lsp/lsp-haskell
 markdown_extensions:
   - pymdownx.superfences
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - codehilite
   - toc:
       permalink: '#'


### PR DESCRIPTION
I noticed the documentation has not been updated in the last five years. This commit fixes the documentation CI build.
The rendered page can be viewed here: https://dschrempf.github.io/lsp-haskell/

- Emoji extension was moved into `mkdocs-material`

- Do not use Docker container which is supposedly intended for local previews (https://squidfunk.github.io/mkdocs-material/getting-started/#with-docker)

- Install the necessary plugins using `pip`

This commit also updates the used GitHub Actions.
